### PR TITLE
[BE] 로그인 기능 구현 및 배포 환경 준비 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "backend/src/main/resources/spring-project-private"]
+	path = backend/src/main/resources/spring-project-private
+	url = https://github.com/Dev-On-Play/spring-project-private.git

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,41 +1,45 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.2.3'
-	id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+    id 'org.springframework.boot' version '3.2.3'
+    id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'devplay'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-	compileOnly 'org.projectlombok:lombok'
+    compileOnly 'org.projectlombok:lombok'
 
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/backend/src/main/java/mos/auth/controller/AuthController.java
+++ b/backend/src/main/java/mos/auth/controller/AuthController.java
@@ -2,7 +2,11 @@ package mos.auth.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import mos.auth.domain.jwt.TokenValues;
 import mos.auth.dto.OauthLoginRequest;
 import mos.auth.dto.TokenResponse;
 import mos.auth.service.AuthService;
@@ -11,17 +15,80 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Arrays;
+
 @Tag(name = "로그인 관련 기능")
 @RestController
 @RequiredArgsConstructor
 public class AuthController {
 
     private final AuthService authService;
+    private final TokenValues tokenValues;
 
     @Operation(summary = "소셜 로그인 요청")
     @PostMapping("/api/auth/login")
     public ResponseEntity<TokenResponse> oauthLogin(@RequestBody OauthLoginRequest oauthLoginRequest) {
         TokenResponse response = authService.oauthLogin(oauthLoginRequest);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "access 토큰, refresh 토큰 갱신")
+    @PostMapping("/api/auth/refresh")
+    public ResponseEntity<TokenResponse> refresh(
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
+        String refreshToken = extractRefreshTokenFromCookie(request);
+        TokenResponse tokenResponse = authService.refresh(refreshToken);
+        Cookie cookie = setUpRefreshTokenCookie(tokenResponse);
+        response.addCookie(cookie);
+        return ResponseEntity.ok(tokenResponse);
+    }
+
+    private String extractRefreshTokenFromCookie(HttpServletRequest request) {
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> cookie.getName().equals("refreshToken"))
+                .map(Cookie::getValue)
+                .findAny()
+                .orElseThrow(IllegalArgumentException::new);    // todo : RefreshTokenNotExistsException
+    }
+
+    private Cookie setUpRefreshTokenCookie(TokenResponse tokenResponse) {
+        Cookie cookie = new Cookie("refreshToken", tokenResponse.refreshToken());
+        cookie.setMaxAge((int) (tokenValues.refreshTokenExpireLength() / 1000L));
+        cookie.setPath("/");
+//        cookie.setHttpOnly(true);     // todo : 서비스 https 적용 이후 활성화하기
+        cookie.setSecure(true);
+        return cookie;
+    }
+
+    @Operation(summary = "로그아웃, access & refresh 토큰 삭제")
+    @PostMapping("/api/auth/logout")
+    public ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = extractRefreshTokenFromCookie(request);
+        authService.oauthLogout(refreshToken);
+        deleteRefreshTokenFromCookie(request, response);
+
+        return ResponseEntity.ok().build();
+    }
+
+    private void deleteRefreshTokenFromCookie(HttpServletRequest request, HttpServletResponse response) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            deleteRefreshTokenIfPresent(response, cookies);
+        }
+    }
+
+    private void deleteRefreshTokenIfPresent(HttpServletResponse response, Cookie[] cookies) {
+        Arrays.stream(cookies)
+                .filter(cookie -> cookie.getName().equals("refreshToken"))
+                .findFirst()
+                .ifPresent(cookie -> deleteCookie(response, cookie));
+    }
+
+    private void deleteCookie(HttpServletResponse response, Cookie cookie) {
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
     }
 }

--- a/backend/src/main/java/mos/auth/controller/AuthController.java
+++ b/backend/src/main/java/mos/auth/controller/AuthController.java
@@ -1,0 +1,27 @@
+package mos.auth.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import mos.auth.dto.OauthLoginRequest;
+import mos.auth.dto.TokenResponse;
+import mos.auth.service.AuthService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "로그인 관련 기능")
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @Operation(summary = "소셜 로그인 요청")
+    @PostMapping("/api/auth/login")
+    public ResponseEntity<TokenResponse> oauthLogin(@RequestBody OauthLoginRequest oauthLoginRequest) {
+        TokenResponse response = authService.oauthLogin(oauthLoginRequest);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/mos/auth/domain/AuthArgumentResolver.java
+++ b/backend/src/main/java/mos/auth/domain/AuthArgumentResolver.java
@@ -1,0 +1,26 @@
+package mos.auth.domain;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(Authenticated.class);
+    }
+
+    @Override
+    public Long resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        return (Long) webRequest.getAttribute("memberId", RequestAttributes.SCOPE_REQUEST);
+    }
+}

--- a/backend/src/main/java/mos/auth/domain/AuthInterceptor.java
+++ b/backend/src/main/java/mos/auth/domain/AuthInterceptor.java
@@ -1,0 +1,29 @@
+package mos.auth.domain;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import mos.auth.domain.jwt.JwtTokenProvider;
+import mos.auth.domain.jwt.TokenValues;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+public class AuthInterceptor implements HandlerInterceptor {
+
+    private final BearerAuthorizationParser bearerAuthorizationParser;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final TokenValues tokenValues;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+                             Object handler) throws Exception {
+        String accessToken = bearerAuthorizationParser.parse(request.getHeader(HttpHeaders.AUTHORIZATION));
+
+        Long memberId = Long.parseLong(jwtTokenProvider.parseSubject(accessToken, tokenValues.secretKey()));
+        request.setAttribute("memberId", memberId);
+        return HandlerInterceptor.super.preHandle(request, response, handler);
+    }
+}

--- a/backend/src/main/java/mos/auth/domain/Authenticated.java
+++ b/backend/src/main/java/mos/auth/domain/Authenticated.java
@@ -1,0 +1,11 @@
+package mos.auth.domain;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Authenticated {
+}

--- a/backend/src/main/java/mos/auth/domain/BearerAuthorizationParser.java
+++ b/backend/src/main/java/mos/auth/domain/BearerAuthorizationParser.java
@@ -1,0 +1,29 @@
+package mos.auth.domain;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Component
+public class BearerAuthorizationParser {
+
+    private static final String TOKEN_TYPE = "Bearer";
+    private static final int TOKEN_TYPE_LOCATION = 0;
+    private static final int ACCESS_TOKEN_LOCATION = 1;
+    private static final int HEADER_SIZE = 2;
+
+    public String parse(String authorizationHeader) {
+        validateIsNonNull(authorizationHeader);
+        String[] split = authorizationHeader.split(" ");
+        if (split.length != HEADER_SIZE || !split[TOKEN_TYPE_LOCATION].equals(TOKEN_TYPE)) {
+            throw new IllegalArgumentException();   //todo : InvalidAuthorizationHeaderException
+        }
+        return split[ACCESS_TOKEN_LOCATION];
+    }
+
+    private void validateIsNonNull(String authorizationHeader) {
+        if (Objects.isNull(authorizationHeader)) {
+            throw new IllegalArgumentException();   //todo : InvalidAuthorizationHeaderException
+        }
+    }
+}

--- a/backend/src/main/java/mos/auth/domain/GoogleOauthValues.java
+++ b/backend/src/main/java/mos/auth/domain/GoogleOauthValues.java
@@ -1,0 +1,20 @@
+package mos.auth.domain;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GoogleOauthValues {
+
+    @Value("${oauth.client-id}")
+    public String clientId;
+
+    @Value("${oauth.client-secret}")
+    public String clientSecret;
+
+    @Value("${oauth.redirect-uri}")
+    public String redirectUri;
+
+    @Value("${oauth.grant-type}")
+    public String grantType;
+}

--- a/backend/src/main/java/mos/auth/domain/GoogleOauthWebClient.java
+++ b/backend/src/main/java/mos/auth/domain/GoogleOauthWebClient.java
@@ -1,0 +1,63 @@
+package mos.auth.domain;
+
+import lombok.RequiredArgsConstructor;
+import mos.auth.dto.OauthAccessTokenResponse;
+import mos.auth.dto.OauthUserProfileResponse;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class GoogleOauthWebClient {
+
+    private static final String REQUEST_TOKEN_URI = "https://oauth2.googleapis.com/token";
+    private static final String REQUEST_USER_PROFILE_URI = "https://www.googleapis.com/oauth2/v3/userinfo";
+
+    private final GoogleOauthValues googleOauthValues;
+
+    public OauthAccessTokenResponse requestOauthAccessToken(String code) {
+        return WebClient.create()
+                .post()
+                .uri(REQUEST_TOKEN_URI)
+                .headers(header -> {
+                    header.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+                    header.setAccept(List.of(MediaType.APPLICATION_JSON));
+                    header.setAcceptCharset(List.of(StandardCharsets.UTF_8));
+                })
+                .bodyValue(createRequestAccessTokenBody(code))
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, response -> response.bodyToMono(String.class)
+                        .map(IllegalArgumentException::new))    // todo : OauthServerException으로 예외처리 해주기
+                .bodyToMono(OauthAccessTokenResponse.class)
+                .block();
+    }
+
+    private MultiValueMap<String, String> createRequestAccessTokenBody(String code) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("code", code);
+        body.add("client_id", googleOauthValues.clientId);
+        body.add("client_secret", googleOauthValues.clientSecret);
+        body.add("redirect_uri", googleOauthValues.redirectUri);
+        body.add("grant_type", googleOauthValues.grantType);
+        return body;
+    }
+
+    public OauthUserProfileResponse requestOauthUserProfile(String accessToken) {
+        return WebClient.create()
+                .post()
+                .uri(REQUEST_USER_PROFILE_URI)
+                .headers(headers -> headers.setBearerAuth(accessToken))
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, response -> response.bodyToMono(String.class)
+                        .map(IllegalArgumentException::new))    // todo : OauthServerException으로 예외처리 해주기
+                .bodyToMono(OauthUserProfileResponse.class)
+                .block();
+    }
+}

--- a/backend/src/main/java/mos/auth/domain/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/mos/auth/domain/jwt/JwtTokenProvider.java
@@ -1,0 +1,50 @@
+package mos.auth.domain.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    public String createAccessToken(String subject, Long accessTokenExpireLength, String secretKey) {
+        Claims claims = generateClaims(subject, accessTokenExpireLength);
+
+        return Jwts.builder()
+                .setHeaderParam("alg", "HS256")
+                .setHeaderParam("typ", "JWT")
+                .setClaims(claims)
+                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)),
+                        SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    private Claims generateClaims(String subject, Long accessTokenExpireLength) {
+        Date now = new Date();
+        Date expiredAt = new Date(now.getTime() + accessTokenExpireLength);
+
+        return Jwts.claims()
+                .setSubject(subject)
+                .setIssuedAt(now)
+                .setExpiration(expiredAt);
+    }
+
+    public String parseSubject(String accessToken, String secretKey) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)))
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody()
+                    .getSubject();
+        } catch (ExpiredJwtException exception) {
+            throw new IllegalArgumentException(); // todo : AccessTokenExpiredException
+        } catch (JwtException exception) {
+            throw new IllegalArgumentException(); // todo : InvalidAccessTokenException
+        }
+
+    }
+}

--- a/backend/src/main/java/mos/auth/domain/jwt/TokenValues.java
+++ b/backend/src/main/java/mos/auth/domain/jwt/TokenValues.java
@@ -1,0 +1,12 @@
+package mos.auth.domain.jwt;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public record TokenValues(
+        @Value("${access-token.secret-key}") String secretKey,
+        @Value("${access-token.expire-length}") long accessTokenExpireLength,
+        @Value("${refresh-token.expire-length}") long refreshTokenExpireLength
+) {
+}

--- a/backend/src/main/java/mos/auth/dto/OauthAccessTokenResponse.java
+++ b/backend/src/main/java/mos/auth/dto/OauthAccessTokenResponse.java
@@ -1,0 +1,9 @@
+package mos.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record OauthAccessTokenResponse(
+        @JsonProperty("token_type") String tokenType,
+        @JsonProperty("access_token") String accessToken,
+        String scope) {
+}

--- a/backend/src/main/java/mos/auth/dto/OauthLoginRequest.java
+++ b/backend/src/main/java/mos/auth/dto/OauthLoginRequest.java
@@ -1,0 +1,4 @@
+package mos.auth.dto;
+
+public record OauthLoginRequest(String oauthProvider, String code) {
+}

--- a/backend/src/main/java/mos/auth/dto/OauthUserProfileResponse.java
+++ b/backend/src/main/java/mos/auth/dto/OauthUserProfileResponse.java
@@ -1,0 +1,10 @@
+package mos.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record OauthUserProfileResponse(
+        String name,
+        String email,
+        @JsonProperty("picture") String profileImageUri
+) {
+}

--- a/backend/src/main/java/mos/auth/dto/TokenResponse.java
+++ b/backend/src/main/java/mos/auth/dto/TokenResponse.java
@@ -2,7 +2,7 @@ package mos.auth.dto;
 
 import mos.auth.entity.RefreshToken;
 
-public record TokenResponse(String AccessToken, String RefreshToken) {
+public record TokenResponse(String accessToken, String refreshToken) {
 
     public static TokenResponse of(String accessToken, RefreshToken refreshToken) {
         return new TokenResponse(accessToken, refreshToken.getUuid().toString());

--- a/backend/src/main/java/mos/auth/dto/TokenResponse.java
+++ b/backend/src/main/java/mos/auth/dto/TokenResponse.java
@@ -1,0 +1,10 @@
+package mos.auth.dto;
+
+import mos.auth.entity.RefreshToken;
+
+public record TokenResponse(String AccessToken, String RefreshToken) {
+
+    public static TokenResponse of(String accessToken, RefreshToken refreshToken) {
+        return new TokenResponse(accessToken, refreshToken.getUuid().toString());
+    }
+}

--- a/backend/src/main/java/mos/auth/entity/RefreshToken.java
+++ b/backend/src/main/java/mos/auth/entity/RefreshToken.java
@@ -46,11 +46,6 @@ public class RefreshToken extends BaseTimeEntity {
         }
     }
 
-    public RefreshToken updateExpireDateTime(long expireLength) {
-        this.expireDateTime = LocalDateTime.now().plus(expireLength, ChronoUnit.MILLIS);
-        return this;
-    }
-
     public void updateUuidAndExpireDateTime(long expireLength) {
         this.uuid = UUID.randomUUID();
         this.expireDateTime = LocalDateTime.now().plus(expireLength, ChronoUnit.MILLIS);

--- a/backend/src/main/java/mos/auth/entity/RefreshToken.java
+++ b/backend/src/main/java/mos/auth/entity/RefreshToken.java
@@ -1,0 +1,59 @@
+package mos.auth.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import mos.common.BaseTimeEntity;
+import mos.member.entity.Member;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class RefreshToken extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID uuid;
+
+    private LocalDateTime expireDateTime;
+
+    public RefreshToken(Member member, UUID uuid, LocalDateTime expireDateTime) {
+        this.member = member;
+        this.uuid = uuid;
+        this.expireDateTime = expireDateTime;
+    }
+
+    public static RefreshToken of(Member member, long expireLength) {
+        return new RefreshToken(member, UUID.randomUUID(),
+                LocalDateTime.now().plus(expireLength, ChronoUnit.MILLIS));
+    }
+
+    public void validateExpired() {
+        if (expireDateTime.isBefore(LocalDateTime.now())) {
+            throw new IllegalArgumentException(); //todo : RefreshTokenExpiredException
+        }
+    }
+
+    public RefreshToken updateExpireDateTime(long expireLength) {
+        this.expireDateTime = LocalDateTime.now().plus(expireLength, ChronoUnit.MILLIS);
+        return this;
+    }
+
+    public void updateUuidAndExpireDateTime(long expireLength) {
+        this.uuid = UUID.randomUUID();
+        this.expireDateTime = LocalDateTime.now().plus(expireLength, ChronoUnit.MILLIS);
+    }
+}
+

--- a/backend/src/main/java/mos/auth/entity/RefreshToken.java
+++ b/backend/src/main/java/mos/auth/entity/RefreshToken.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import mos.common.BaseTimeEntity;
+import mos.common.entity.BaseTimeEntity;
 import mos.member.entity.Member;
 
 import java.time.LocalDateTime;

--- a/backend/src/main/java/mos/auth/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/mos/auth/repository/RefreshTokenRepository.java
@@ -1,7 +1,16 @@
 package mos.auth.repository;
 
 import mos.auth.entity.RefreshToken;
+import mos.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+import java.util.UUID;
+
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByUuid(UUID uuid);
+
+    Optional<RefreshToken> findByMember(Member member);
+
+    boolean existsByUuid(UUID uuid);
 }

--- a/backend/src/main/java/mos/auth/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/mos/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package mos.auth.repository;
+
+import mos.auth.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+}

--- a/backend/src/main/java/mos/auth/service/AuthService.java
+++ b/backend/src/main/java/mos/auth/service/AuthService.java
@@ -26,4 +26,12 @@ public class AuthService {
         // 사용자 프로필 정보를 이용해서 로그인 프로세스 진행 후 access, refresh Token 발급
         return authTransactionalService.userLogin(profileResponse);
     }
+
+    public TokenResponse refresh(String refreshToken) {
+        return authTransactionalService.republishAccessAndRefreshToken(refreshToken);
+    }
+
+    public void oauthLogout(String refreshToken) {
+        authTransactionalService.deleteRefreshToken(refreshToken);
+    }
 }

--- a/backend/src/main/java/mos/auth/service/AuthService.java
+++ b/backend/src/main/java/mos/auth/service/AuthService.java
@@ -1,0 +1,29 @@
+package mos.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import mos.auth.domain.GoogleOauthWebClient;
+import mos.auth.dto.OauthAccessTokenResponse;
+import mos.auth.dto.OauthLoginRequest;
+import mos.auth.dto.OauthUserProfileResponse;
+import mos.auth.dto.TokenResponse;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final GoogleOauthWebClient googleOauthWebClient;
+
+    private final AuthTransactionalService authTransactionalService;
+
+    public TokenResponse oauthLogin(OauthLoginRequest request) {
+        // client로부터 전달받은 code를 이용해 oauth accessToken을 구글 서버에 요청
+        OauthAccessTokenResponse response = googleOauthWebClient.requestOauthAccessToken(request.code());
+
+        // 그 뒤 oauth accessToken을 사용해서 사용자 프로필 정보 요청해서 가져오기
+        OauthUserProfileResponse profileResponse = googleOauthWebClient.requestOauthUserProfile(response.accessToken());
+
+        // 사용자 프로필 정보를 이용해서 로그인 프로세스 진행 후 access, refresh Token 발급
+        return authTransactionalService.userLogin(profileResponse);
+    }
+}

--- a/backend/src/main/java/mos/auth/service/AuthTransactionalService.java
+++ b/backend/src/main/java/mos/auth/service/AuthTransactionalService.java
@@ -1,0 +1,48 @@
+package mos.auth.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import mos.auth.domain.jwt.JwtTokenProvider;
+import mos.auth.domain.jwt.TokenValues;
+import mos.auth.dto.OauthUserProfileResponse;
+import mos.auth.dto.TokenResponse;
+import mos.auth.entity.RefreshToken;
+import mos.auth.repository.RefreshTokenRepository;
+import mos.member.entity.Member;
+import mos.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthTransactionalService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final TokenValues tokenValues;
+
+    private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public TokenResponse userLogin(OauthUserProfileResponse response) {
+        // 멤버 정보가 기존에 존재했으면 업데이트, 아니면 새로 생성
+        Member member = createOrUpdateMember(response);
+        return publishAccessAndRefreshToken(member);
+    }
+
+    private Member createOrUpdateMember(OauthUserProfileResponse response) {
+        Member member = memberRepository.findByNicknameAndEmail(response.name(), response.email())
+                .orElseGet(() -> Member.createNewMember(response.name(), response.email(), response.profileImageUri()));
+        member.updateProfileImageUri(response.profileImageUri());
+        return memberRepository.save(member);
+    }
+
+    private TokenResponse publishAccessAndRefreshToken(Member member) {
+        // jwt accessToken, refreshToken 신규 발급 후 반환
+        String accessToken = jwtTokenProvider.createAccessToken(String.valueOf(member.getId()), tokenValues.accessTokenExpireLength(),
+                tokenValues.secretKey());
+        RefreshToken refreshToken = RefreshToken.of(member, tokenValues.refreshTokenExpireLength());
+        refreshTokenRepository.save(refreshToken);
+
+        return TokenResponse.of(accessToken, refreshToken);
+    }
+}

--- a/backend/src/main/java/mos/common/entity/BaseTimeEntity.java
+++ b/backend/src/main/java/mos/common/entity/BaseTimeEntity.java
@@ -1,4 +1,4 @@
-package mos.common;
+package mos.common.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;

--- a/backend/src/main/java/mos/common/exception/ExceptionAdvice.java
+++ b/backend/src/main/java/mos/common/exception/ExceptionAdvice.java
@@ -1,0 +1,21 @@
+package mos.common.exception;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ExceptionAdvice {
+
+    Logger defaultLog = LoggerFactory.getLogger(ExceptionAdvice.class);
+    Logger exceptionLog = LoggerFactory.getLogger("ExceptionLogger");
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Void> handleException(Exception e) {
+        defaultLog.error(e.getMessage());
+        exceptionLog.error(e.getMessage(), e);
+        return ResponseEntity.internalServerError().build();
+    }
+}

--- a/backend/src/main/java/mos/config/WebMvcConfiguration.java
+++ b/backend/src/main/java/mos/config/WebMvcConfiguration.java
@@ -1,11 +1,22 @@
 package mos.config;
 
+import lombok.RequiredArgsConstructor;
+import mos.auth.domain.AuthArgumentResolver;
+import mos.auth.domain.AuthInterceptor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.List;
+
 @Configuration
+@RequiredArgsConstructor
 public class WebMvcConfiguration implements WebMvcConfigurer {
+
+    private final AuthInterceptor authInterceptor;
+    private final AuthArgumentResolver authArgumentResolver;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -13,5 +24,17 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
                 .allowedOriginPatterns("*")
                 .allowedMethods("*");
 //                .allowCredentials(true);  //이후 인증,인가 기능 추가 시 설정 예정
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor)
+                .addPathPatterns("/api/members/**");
+//                .excludePathPatterns("/api/**");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authArgumentResolver);
     }
 }

--- a/backend/src/main/java/mos/contents/entity/Comment.java
+++ b/backend/src/main/java/mos/contents/entity/Comment.java
@@ -3,7 +3,7 @@ package mos.contents.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import mos.common.BaseTimeEntity;
+import mos.common.entity.BaseTimeEntity;
 import mos.member.entity.Member;
 import mos.mogako.entity.Mogako;
 

--- a/backend/src/main/java/mos/contents/entity/SavedFile.java
+++ b/backend/src/main/java/mos/contents/entity/SavedFile.java
@@ -3,7 +3,7 @@ package mos.contents.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import mos.common.BaseTimeEntity;
+import mos.common.entity.BaseTimeEntity;
 import mos.mogako.entity.Mogako;
 
 @Entity

--- a/backend/src/main/java/mos/member/controller/MemberController.java
+++ b/backend/src/main/java/mos/member/controller/MemberController.java
@@ -3,9 +3,9 @@ package mos.member.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import mos.auth.domain.Authenticated;
 import mos.member.dto.MemberResponse;
 import mos.member.dto.UpdateMemberRequest;
-import mos.member.entity.Member;
 import mos.member.service.MemberService;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -18,31 +18,27 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    private final Member dummyMember = Member.createNewMember("닉네임1",
-            "test1@gmail.com", "프로필url1");
-
     @Operation(summary = "단일 멤버정보 조회")
     @GetMapping("/api/members/{memberId}")
-    public ResponseEntity<MemberResponse> findMember(@PathVariable Long memberId) {
+    public ResponseEntity<MemberResponse> findMember(@Authenticated Long authMemberId, @PathVariable Long memberId) {
         MemberResponse response = memberService.findMember(memberId);
         return ResponseEntity.ok(response);
     }
 
-    // todo : 로그인 기능 구현 이후 인가 관련 코드 추가하며 구현 예정
+    // todo : 서비스 확장 과정에서 외부로 노출되어선 안되는 멤버 정보가 생기면 단일 멤버 정보 조회 API와 구분할 필요가 있어짐.
     @Operation(summary = "나의 멤버정보 조회")
     @GetMapping("/api/members/me")
-    public ResponseEntity<MemberResponse> findMe() {
-        MemberResponse response = MemberResponse.from(dummyMember);
+    public ResponseEntity<MemberResponse> findMe(@Authenticated Long authMemberId) {
+        MemberResponse response = memberService.findMember(authMemberId);
         return ResponseEntity.ok(response);
     }
 
-    // todo : 로그인 기능 구현 이후 인가 관련 코드 추가하며 구현 예정
     @Operation(summary = "나의 멤버정보 수정")
     @PutMapping("/api/members/me")
-    public ResponseEntity<Void> updateMe(@RequestBody UpdateMemberRequest request) {
-        Long updatedMemberId = 1L;
+    public ResponseEntity<Void> updateMe(@Authenticated Long authMemberId, @RequestBody UpdateMemberRequest request) {
+        Long updatedMemberId = memberService.updateMember(authMemberId, request);
         return ResponseEntity.noContent()
-                .header(HttpHeaders.LOCATION, "api/mogakos/" + updatedMemberId)
+                .header(HttpHeaders.LOCATION, "api/members/" + updatedMemberId)
                 .build();
     }
 }

--- a/backend/src/main/java/mos/member/controller/MemberController.java
+++ b/backend/src/main/java/mos/member/controller/MemberController.java
@@ -18,8 +18,8 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    private final Member dummyMember = Member.createNewMember("닉네임1", "test1@gmail.com", "소개글1",
-            "프로필url1", 36.5);
+    private final Member dummyMember = Member.createNewMember("닉네임1",
+            "test1@gmail.com", "프로필url1");
 
     @Operation(summary = "단일 멤버정보 조회")
     @GetMapping("/api/members/{memberId}")

--- a/backend/src/main/java/mos/member/dto/UpdateMemberRequest.java
+++ b/backend/src/main/java/mos/member/dto/UpdateMemberRequest.java
@@ -1,5 +1,4 @@
 package mos.member.dto;
 
-public record UpdateMemberRequest(String nickname, String email,
-                                  String introduction, String profile) {
+public record UpdateMemberRequest(String nickname, String introduction, String profile) {
 }

--- a/backend/src/main/java/mos/member/entity/Member.java
+++ b/backend/src/main/java/mos/member/entity/Member.java
@@ -7,7 +7,7 @@ import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import mos.common.BaseTimeEntity;
+import mos.common.entity.BaseTimeEntity;
 
 @Entity
 @Getter

--- a/backend/src/main/java/mos/member/entity/Member.java
+++ b/backend/src/main/java/mos/member/entity/Member.java
@@ -46,4 +46,10 @@ public class Member extends BaseTimeEntity {
             this.profile = updatedProfileImageUri;
         }
     }
+
+    public void update(String nickname, String introduction, String profile) {
+        this.nickname = nickname;
+        this.introduction = introduction;
+        this.profile = profile;
+    }
 }

--- a/backend/src/main/java/mos/member/entity/Member.java
+++ b/backend/src/main/java/mos/member/entity/Member.java
@@ -14,6 +14,9 @@ import mos.common.BaseTimeEntity;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseTimeEntity {
 
+    public static final String DEFAULT_INTRODUCTION = "안녕하세요. %s입니다.";
+    public static final double DEFAULT_CREDIBILITY = 36.5;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -33,9 +36,14 @@ public class Member extends BaseTimeEntity {
         this.credibility = credibility;
     }
 
-    public static Member createNewMember(String nickname, String email,
-                                         String introduction, String profile, double credibility) {
-        return new Member(nickname, email, introduction, profile, credibility);
+    public static Member createNewMember(String nickname, String email, String profile) {
+        return new Member(nickname, email, String.format(DEFAULT_INTRODUCTION, nickname),
+                profile, DEFAULT_CREDIBILITY);
     }
 
+    public void updateProfileImageUri(String updatedProfileImageUri) {
+        if (!this.profile.equals(updatedProfileImageUri)) {
+            this.profile = updatedProfileImageUri;
+        }
+    }
 }

--- a/backend/src/main/java/mos/member/repository/MemberRepository.java
+++ b/backend/src/main/java/mos/member/repository/MemberRepository.java
@@ -3,6 +3,9 @@ package mos.member.repository;
 import mos.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    Optional<Member> findByNicknameAndEmail(String nickname, String email);
 }

--- a/backend/src/main/java/mos/member/service/MemberService.java
+++ b/backend/src/main/java/mos/member/service/MemberService.java
@@ -3,6 +3,7 @@ package mos.member.service;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import mos.member.dto.MemberResponse;
+import mos.member.dto.UpdateMemberRequest;
 import mos.member.entity.Member;
 import mos.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
@@ -18,5 +19,13 @@ public class MemberService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 멤버 Id 입니다."));
         return MemberResponse.from(member);
+    }
+
+    public Long updateMember(Long memberId, UpdateMemberRequest request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 멤버 Id 입니다."));
+
+        member.update(request.nickname(), request.introduction(), request.profile());
+        return member.getId();
     }
 }

--- a/backend/src/main/java/mos/mogako/entity/Mogako.java
+++ b/backend/src/main/java/mos/mogako/entity/Mogako.java
@@ -5,7 +5,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mos.category.entity.Category;
-import mos.common.BaseTimeEntity;
+import mos.common.entity.BaseTimeEntity;
 import mos.hashtag.entity.MogakoHashtag;
 
 import java.time.LocalDateTime;

--- a/backend/src/main/java/mos/participant/entity/Participant.java
+++ b/backend/src/main/java/mos/participant/entity/Participant.java
@@ -3,7 +3,7 @@ package mos.participant.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import mos.common.BaseTimeEntity;
+import mos.common.entity.BaseTimeEntity;
 import mos.member.entity.Member;
 import mos.mogako.entity.Mogako;
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -8,6 +8,9 @@ spring:
     url: jdbc:h2:mem:mos
     username: sa
     password:
+  config:
+    import:
+      classpath:/spring-project-private/application-secret.yml
 
 springdoc:
   swagger-ui:

--- a/backend/src/main/resources/console-appender.xml
+++ b/backend/src/main/resources/console-appender.xml
@@ -1,0 +1,7 @@
+<included>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </layout>
+    </appender>
+</included>

--- a/backend/src/main/resources/default-appender.xml
+++ b/backend/src/main/resources/default-appender.xml
@@ -1,0 +1,19 @@
+<included>
+    <appender name="DEFAULT" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/default/default.log</file>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>INFO</level>
+        </filter>
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/default/default.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>20MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>100MB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+</included>

--- a/backend/src/main/resources/error-appender.xml
+++ b/backend/src/main/resources/error-appender.xml
@@ -1,0 +1,19 @@
+<included>
+    <appender name="ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/warn-error/warn-error.log</file>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>WARN</level>
+        </filter>
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/warn-error/warn-error.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>5MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>20MB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+</included>

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <property name="LOG_PATH" value="./logs"/>
+
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%green(%d{yyyy-MM-dd HH:mm:ss.SSS, ${logback.timezone:-Asia/Seoul}}) %magenta([%thread]) %clr(%5level) %cyan(%logger) - %yellow(%msg%n)"/>
+    <property name="FILE_LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS, ${logback.timezone:-Asia/Seoul}} [%thread] %5level %logger - %msg%n"/>
+
+    <include resource="console-appender.xml"/>
+    <include resource="default-appender.xml"/>
+    <include resource="error-appender.xml"/>
+
+    <logger name="ExceptionLogger" level="WARN" additivity="false">
+        <appender-ref ref="ERROR"/>
+    </logger>
+
+    <root level="INFO">
+        <springProfile name="develop,production">
+            <appender-ref ref="DEFAULT"/>
+        </springProfile>
+        <springProfile name="default">
+            <appender-ref ref="CONSOLE"/>
+        </springProfile>
+    </root>
+</configuration>

--- a/backend/src/test/java/mos/contents/service/CommentServiceTest.java
+++ b/backend/src/test/java/mos/contents/service/CommentServiceTest.java
@@ -2,7 +2,6 @@ package mos.contents.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.mockito.Mockito.mock;
 
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
@@ -12,7 +11,10 @@ import mos.contents.dto.CreateCommentRequest;
 import mos.contents.entity.Comment;
 import mos.member.entity.Member;
 import mos.mogako.entity.Mogako;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
@@ -40,11 +42,11 @@ class CommentServiceTest {
     @BeforeEach
     void setup() {
         category = Category.createCategory("category1");
-        mogako = Mogako.createNewMogako("samplemogakp","summary", category,
+        mogako = Mogako.createNewMogako("samplemogakp", "summary", category,
                 LocalDateTime.now().plusDays(1L), LocalDateTime.now().plusDays(2L),
                 8, 2,
                 "detailcontent");
-        member = Member.createNewMember("nick","aaa@aaa.aaa","intro","profileurl",36.5);
+        member = Member.createNewMember("nick", "aaa@aaa.aaa", "profileurl");
         pComment = Comment.createNewComment(mogako, member, "댓글 테스트");
         entityManager.persist(category);
         entityManager.persist(mogako);

--- a/backend/src/test/java/mos/integration/CommentIntegrationTest.java
+++ b/backend/src/test/java/mos/integration/CommentIntegrationTest.java
@@ -1,10 +1,9 @@
 package mos.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import mos.category.entity.Category;
 import mos.contents.dto.CommentResponse;
@@ -15,11 +14,8 @@ import mos.member.entity.Member;
 import mos.mogako.entity.Mogako;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.util.LinkedMultiValueMap;
 
@@ -46,7 +42,7 @@ class CommentIntegrationTest extends IntegrationTest {
                 LocalDateTime.now().plusDays(1L), LocalDateTime.now().plusDays(2L),
                 8, 2,
                 "모각코 상세설명");
-        member = Member.createNewMember("nick","aaa@aaa.aa","intro","profileurl",36.5);
+        member = Member.createNewMember("nick", "aaa@aaa.aa", "profileurl");
         comment1 = Comment.createNewComment(mogako, member, "신규 댓글 1");
         comment2 = Comment.createNewComment(mogako, member, "신규 댓글 2");
 

--- a/backend/src/test/java/mos/integration/MemberIntegrationTest.java
+++ b/backend/src/test/java/mos/integration/MemberIntegrationTest.java
@@ -12,20 +12,16 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import java.nio.charset.StandardCharsets;
 
+@SuppressWarnings("NonAsciiCharacters")
 class MemberIntegrationTest extends IntegrationTest {
 
     private Member member1;
-    private Member member2;
 
     @BeforeEach
     void setUp() {
-        member1 = Member.createNewMember("닉네임1", "test1@gmail.com", "소개글1",
-                "프로필url1", 36.5);
-        member2 = Member.createNewMember("닉네임2", "test2@gmail.com", "소개글2",
-                "프로필url2", 40.0);
+        member1 = Member.createNewMember("닉네임1", "test1@gmail.com", "프로필url1");
 
         entityManager.persist(member1);
-        entityManager.persist(member2);
 
         entityManager.flush();
         entityManager.clear();

--- a/backend/src/test/java/mos/member/entity/MemberTest.java
+++ b/backend/src/test/java/mos/member/entity/MemberTest.java
@@ -4,12 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("NonAsciiCharacters")
 class MemberTest {
 
     @Test
     void 멤버_생성_테스트() {
         // given, then
-        assertDoesNotThrow(() -> Member.createNewMember("닉네임", "testemail@gmail.com",
-                "자기소개", "프로필 사진 url", 36.5));
+        assertDoesNotThrow(() -> Member.createNewMember("닉네임", "testemail@gmail.com", "프로필 사진 url"));
     }
 }

--- a/backend/src/test/java/mos/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/mos/member/service/MemberServiceTest.java
@@ -26,17 +26,12 @@ class MemberServiceTest {
     private EntityManager entityManager;
 
     private Member member1;
-    private Member member2;
 
     @BeforeEach
     void setUp() {
-        member1 = Member.createNewMember("닉네임1", "test1@gmail.com",
-                "소개글1", "프로필url1", 36.5);
-        member2 = Member.createNewMember("닉네임2", "test2@gmail.com",
-                "소개글2", "프로필url2", 40.0);
+        member1 = Member.createNewMember("닉네임1", "test1@gmail.com", "프로필url1");
 
         entityManager.persist(member1);
-        entityManager.persist(member2);
 
         entityManager.flush();
         entityManager.clear();


### PR DESCRIPTION
구현사항
- 구글 Oauth 로그인 로직 구현을 완료하고 accessToken, refreshToken 발급 로직을 구현 완료했습니다. 로그인 전체 플로우에 대한 설명은 별첨된 [wiki 페이지 설명](https://github.com/Dev-On-Play/spring-project/wiki/Google-Oauth-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EC%A0%84%EC%B2%B4-%ED%94%8C%EB%A1%9C%EC%9A%B0-%EB%AA%85%EC%84%B8)을 참조해주세요.
- 아직 모각코 관련 API 에서 해시태그 기능 구현이 덜 되었지만 일단 프론트 분들이 전체적인 API 흐름을 파악하고 사용하면 작업하시기에 차질은 없을 것 같다는 생각이 들어 부랴부랴 배포 준비를 좀 같이 해보았습니다.
- 프론트 단 페이지에서도 API 연동 작업이 얼른 진행되어야 할 듯 싶어 배포환경에서 필요한 작업들을 수행했습니다.
  - 현재 백엔드 서버 설정은 로컬 환경에서 실행되도록 구현해둬서 기존처럼 @hdwhdwhdw 대원님이 배포해주시면 될 것 같습니다만, 로그인 관련 설정 정보들을 분리하기 위해 서브 모듈을 사용한 터라 이후 jar 파일 빌드 시 저희 organization에서 관리하는 spring-project-private 저장소를 `backend/src/main/resources/spring-project-private` 경로에 서브모듈로 추가해주신 뒤 로컬에서 정상 실행 확인하신 후 빌드해서 배포해주시면 될 것 같습니다.
- 배포 환경에서 트러블 슈팅을 위해 예외 상황들에 대한 로깅 기능을 구현해뒀습니다. 서버에서 발생하는 예외 상황들에 대한 메세지는 jar 파일 위치 기준에서 logs 폴더 내에 생성되도록 했으니 이후 트러블 슈팅 간 참고하면 될 것 같습니다.

제가 최근 이런 저런 일이 좀 많이 생겨서 코드 퀄리티에 대한 욕심을 내려놓고 일단 돌아가는 코드로만 구현을 해뒀습니다. 7/16일 이후로 아마 좀 한가해질 것 같다고 예상은 하고 있는데... 이후 미구현된 해시태그 기능 쪽을 마무리하면 기본적인 백엔드 로직은 전부 구현할 수 있을 것 같습니다. 혹시 잘 안되거나 이상한 부분 있다면 언제든 말씀부탁드립니다.