### PR TITLE
feat : 모각코 google 로그인 연동

### DIFF
--- a/frontend/api/fetchApi.ts
+++ b/frontend/api/fetchApi.ts
@@ -1,3 +1,4 @@
+import { getItem } from "@/store/localStorage"
 import axios, { Method } from "axios"
 
 export const instance = axios.create({
@@ -36,7 +37,8 @@ const fetchApi = async (
     data?: { [key: string]: any }
     params?: any
     headers?: any
-  }
+  },
+  etc?: { isAuth: boolean }
 ) => {
   const headers = opts.headers
     ? { ...opts.headers }
@@ -46,7 +48,12 @@ const fetchApi = async (
     url: apiUrl,
     data: opts.data,
     params: opts.params,
-    headers: headers,
+    headers: etc?.isAuth
+      ? {
+          ...headers,
+          Authorization: `Bearer ${getItem({ key: "accessToken" })}`,
+        }
+      : headers,
   })
     .then((res) => {
       return { ...res }

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -1,63 +1,61 @@
 "use client"
 
+import fetchApi from "@/api/fetchApi"
+import { getItem, setItem } from "@/store/localStorage"
+import { useLoadingStore } from "@/store/store"
 import { useCallback, useEffect, useState } from "react"
 import { NextPage } from "next"
+import { useRouter } from "next/navigation"
 import GoogleIcon from "@/components/icons/GoogleIcon"
 import KakaoIcon from "@/components/icons/kakaoIcon"
 import NaverIcon from "@/components/icons/NaverIcon"
 
 interface Props {}
 const Login: NextPage<Props> = ({}) => {
-  //카카오 로그인시 리턴 인가 코드
-  const [code, setCode] = useState<string | undefined | null>()
-  const redirect_uri = `${process.env.NEXT_PUBLIC_DOMAIN}/login` //Redirect URI
-  if (
-    typeof window !== "undefined" &&
-    new URL(window.location.href).searchParams.get("code") &&
-    !code
-  ) {
-    //정상적으로 인가코드 정보를 받았을때
-    setCode(new URL(window.location.href).searchParams.get("code"))
-  }
+  const router = useRouter()
+  const { isLoading, offLoading, onLoading } = useLoadingStore()
+  //로그인시 리턴 인가 코드
+  const [code, setCode] = useState<string | undefined | null>("")
+  useEffect(() => {
+    const accessToken = getItem({ key: "accessToken" })
+    // logout()
+    if (accessToken) {
+      //엑세스 토큰 유효성 검증 로직 필요함
+      console.log(accessToken)
+    }
+    if (
+      typeof window !== "undefined" &&
+      new URL(window.location.href).searchParams.get("code") &&
+      !code
+    ) {
+      //정상적으로 인가코드 정보를 받았을때
+      setCode(new URL(window.location.href).searchParams.get("code"))
+    }
+  }, [])
+
   // 인가 코드 받기 요청 실패
   // error 및 error_description이 전달된 경우
   // 문제 해결, 응답 코드를 참고해 에러 원인별 상황에 맞는 서비스 페이지나 안내 문구를 사용자에게 보여주도록 처리
   // => #todo
-
-  //로그인 REST API
-  const kakaoRestApi = () => {
-    //https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api 참고 문서
-    // oauth 요청 URL
-    const kakaoURL = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_REST_API_KEY}&redirect_uri=${redirect_uri}&response_type=code`
-    //로그인 실패시 or 기존 인가코드를 가지고 있다면 code 를 초기화
-    if (code) {
-      setCode("")
-    }
-    window.location.href = kakaoURL
-  }
-
-  const naverLogin = () => {
-    const callbackUrl = `${process.env.NEXT_PUBLIC_DOMAIN}/login`
-    const clientId = process.env.NEXT_PUBLIC_NAVER_CLIENT_ID
-    const apiUrl = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${clientId}&redirect_uri=${callbackUrl}`
-    if (code) {
-      setCode("")
-    }
-    window.location.href = apiUrl
-  }
-
-  const googleLogin = () => {
-    // redirect_uri
-    const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID
-    const apiUrl = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${clientId}&redirect_uri=${redirect_uri}&response_type=code&scope=email profile`
-    if (code) {
-      setCode("")
-    }
-    window.location.href = apiUrl
-  }
   // 실제 로그인 처리
-  const loginProcessing = useCallback(() => {
-    console.log("백엔드로 인가코드 전달", code)
+  const loginProcessing = useCallback(async () => {
+    onLoading()
+    await fetchApi("/auth/login", {
+      method: "post",
+      data: {
+        oauthProvider: getItem({ key: "loginType" }),
+        code: code,
+      },
+    })
+      .then((res) => {
+        setItem({ key: "accessToken", item: res.data.accessToken })
+        offLoading()
+        const lastPath = getItem({ key: "lastPath" })
+        lastPath ? router.push(lastPath) : router.push("mainPage")
+      })
+      .catch((err) => {
+        offLoading()
+      })
   }, [code])
   useEffect(() => {
     if (code) {
@@ -65,41 +63,52 @@ const Login: NextPage<Props> = ({}) => {
     }
   }, [code, loginProcessing])
   const loginHandler = (trigger: string) => {
+    setItem({ key: "loginType", item: trigger })
+    const redirect_uri = `${process.env.NEXT_PUBLIC_DOMAIN}/login` //Redirect URI
+    let loginURL = ""
     if (trigger.includes("k")) {
-      kakaoRestApi()
-    } else if (trigger.includes("n")) {
-      naverLogin()
-    } else if (trigger.includes("g")) {
-      console.log("구글 로그인")
-      googleLogin()
+      loginURL = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_REST_API_KEY}&redirect_uri=${redirect_uri}&response_type=code`
     }
+    if (trigger.includes("n")) {
+      loginURL = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${process.env.NEXT_PUBLIC_NAVER_CLIENT_ID}&redirect_uri=${redirect_uri}`
+    }
+    if (trigger.includes("g")) {
+      loginURL = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID}&redirect_uri=${redirect_uri}&response_type=code&scope=email profile`
+    }
+    if (code) {
+      setCode("")
+    }
+    window.location.href = loginURL
   }
+
   return (
-    <div className="container flex h-[800px] max-w-[750px] flex-col place-content-between items-center justify-center">
-      <p className="text-[48px] font-bold">모각코 로그인</p>
-      <div
-        className="mb-[10px] rounded-2xl shadow-md hover:cursor-pointer"
-        onClick={() => {
-          loginHandler("k")
-        }}
-      >
-        <KakaoIcon />
-      </div>
-      <div
-        className="mb-[10px] rounded-2xl shadow-md hover:cursor-pointer"
-        onClick={() => {
-          loginHandler("n")
-        }}
-      >
-        <NaverIcon />
-      </div>
-      <div
-        className="mb-[10px] rounded-2xl shadow-md hover:cursor-pointer"
-        onClick={() => {
-          loginHandler("g")
-        }}
-      >
-        <GoogleIcon />
+    <div suppressHydrationWarning>
+      <div className="container flex h-[800px] max-w-[750px] flex-col place-content-between items-center justify-center">
+        <p className="text-[48px] font-bold">모각코 로그인</p>
+        <div
+          className="mb-[10px] rounded-2xl shadow-md hover:cursor-pointer"
+          onClick={() => {
+            loginHandler("kakao")
+          }}
+        >
+          <KakaoIcon />
+        </div>
+        <div
+          className="mb-[10px] rounded-2xl shadow-md hover:cursor-pointer"
+          onClick={() => {
+            loginHandler("naver")
+          }}
+        >
+          <NaverIcon />
+        </div>
+        <div
+          className="mb-[10px] rounded-2xl shadow-md hover:cursor-pointer"
+          onClick={() => {
+            loginHandler("google")
+          }}
+        >
+          <GoogleIcon />
+        </div>
       </div>
     </div>
   )

--- a/frontend/components/layout/Header.tsx
+++ b/frontend/components/layout/Header.tsx
@@ -1,12 +1,16 @@
 "use client"
 
+import { getItem, setItem } from "@/store/localStorage"
 import { useRouter } from "next/navigation"
 
 export default function Header() {
   const router = useRouter()
   const goPage = () => {
     // 로그인 유무 체크 후 마이페이지 또는 로그인 페이지로 이동
-    router.push("/login")
+    const accessToken = getItem({ key: "accessToken" })
+    //라스트 패스 저장
+    !accessToken ? setItem({ key: "lastPath", item: "/mypage" }) : undefined
+    accessToken ? router.push("/mypage") : router.push("/login")
   }
   return (
     <div className="flex flex-row justify-around pt-6">

--- a/frontend/store/localStorage.ts
+++ b/frontend/store/localStorage.ts
@@ -1,0 +1,17 @@
+const setItem = ({ key, item }: { key: string; item: string }) => {
+  if (typeof window !== "undefined") {
+    localStorage.setItem(key, item)
+  }
+}
+const getItem = ({ key }: { key: string }) => {
+  if (typeof window !== "undefined") {
+    return localStorage.getItem(key)
+  }
+  return null
+}
+const removeItem = ({ key }: { key: string }) => {
+  if (typeof window !== "undefined") {
+    localStorage.removeItem(key)
+  }
+}
+export { setItem, getItem, removeItem }


### PR DESCRIPTION
mypage 아이콘 클릭시 엑세스토큰 유무 체크 하여 로그인 페이지 or 마이페이지 이동 로그인 페이지 이동시 lastPath 별도로 저장 , 로그인 완료후 lastPath 이동가능 하게 처리 로그인 완료후 엑세스 토큰 로컬 스토리지 저장
공통 fetchApi.ts auth 기능 필요시 {isAuth: true/false(default)} 입력 하면
 Header 에 "Authorization": "Bearer "accessToken"" 추가 되게 처리함

.env 환경 변수 파일 NEXT_PUBLIC_GOOGLE_CLIENT_ID 를 application-secret.yml 에 설정된  client-id 로 변경
 application-secret.yml redirect-uri => http://localhost:3000/login
 2개 변경해야 정상적으로 로그인 테스트 가능함