### PR TITLE
[BE] google Oauth 로그인 시 리프레시 토큰 쿠키 등록 기능 추가

### DIFF
--- a/backend/src/main/java/mos/auth/controller/AuthController.java
+++ b/backend/src/main/java/mos/auth/controller/AuthController.java
@@ -28,9 +28,11 @@ public class AuthController {
 
     @Operation(summary = "소셜 로그인 요청")
     @PostMapping("/api/auth/login")
-    public ResponseEntity<TokenResponse> oauthLogin(@RequestBody OauthLoginRequest oauthLoginRequest) {
-        TokenResponse response = authService.oauthLogin(oauthLoginRequest);
-        return ResponseEntity.ok(response);
+    public ResponseEntity<TokenResponse> oauthLogin(HttpServletResponse response, @RequestBody OauthLoginRequest oauthLoginRequest) {
+        TokenResponse tokenResponse = authService.oauthLogin(oauthLoginRequest);
+        Cookie cookie = setUpRefreshTokenCookie(tokenResponse);
+        response.addCookie(cookie);
+        return ResponseEntity.ok(tokenResponse);
     }
 
     @Operation(summary = "access 토큰, refresh 토큰 갱신")
@@ -58,7 +60,7 @@ public class AuthController {
         Cookie cookie = new Cookie("refreshToken", tokenResponse.refreshToken());
         cookie.setMaxAge((int) (tokenValues.refreshTokenExpireLength() / 1000L));
         cookie.setPath("/");
-//        cookie.setHttpOnly(true);     // todo : 서비스 https 적용 이후 활성화하기
+        cookie.setHttpOnly(true);
         cookie.setSecure(true);
         return cookie;
     }

--- a/backend/src/main/java/mos/auth/dto/TokenResponse.java
+++ b/backend/src/main/java/mos/auth/dto/TokenResponse.java
@@ -1,8 +1,9 @@
 package mos.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import mos.auth.entity.RefreshToken;
 
-public record TokenResponse(String accessToken, String refreshToken) {
+public record TokenResponse(String accessToken, @JsonIgnore String refreshToken) {
 
     public static TokenResponse of(String accessToken, RefreshToken refreshToken) {
         return new TokenResponse(accessToken, refreshToken.getUuid().toString());

--- a/backend/src/main/java/mos/config/WebMvcConfiguration.java
+++ b/backend/src/main/java/mos/config/WebMvcConfiguration.java
@@ -3,6 +3,7 @@ package mos.config;
 import lombok.RequiredArgsConstructor;
 import mos.auth.domain.AuthArgumentResolver;
 import mos.auth.domain.AuthInterceptor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -18,19 +19,22 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
     private final AuthInterceptor authInterceptor;
     private final AuthArgumentResolver authArgumentResolver;
 
+    @Value("${cors-allow-origin}")
+    String corsAllowOrigin;
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
-                .allowedOriginPatterns("*")
-                .allowedMethods("*");
-//                .allowCredentials(true);  // todo : 이후 인증,인가 기능 추가 시 설정 예정
+                .allowedOriginPatterns(corsAllowOrigin)
+                .allowedMethods("*")
+                .allowCredentials(true);
     }
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authInterceptor)
-                .addPathPatterns("/api/members/**");
-//                .excludePathPatterns("/api/**"); // todo : 이후 인증,인가 기능 추가 시 설정 예정
+                .addPathPatterns("/api/**")
+                .excludePathPatterns("/api/auth/**");
     }
 
     @Override

--- a/backend/src/main/java/mos/member/entity/Member.java
+++ b/backend/src/main/java/mos/member/entity/Member.java
@@ -27,8 +27,8 @@ public class Member extends BaseTimeEntity {
     private String profile;
     private Double credibility;
 
-    public Member(String nickname, String email,
-                  String introduction, String profile, Double credibility) {
+    private Member(String nickname, String email,
+                   String introduction, String profile, Double credibility) {
         this.nickname = nickname;
         this.email = email;
         this.introduction = introduction;

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -15,3 +15,5 @@ spring:
 springdoc:
   swagger-ui:
     path: /swagger/docs
+
+cors-allow-origin: https://https://k-mos.site

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -16,4 +16,4 @@ springdoc:
   swagger-ui:
     path: /swagger/docs
 
-cors-allow-origin: https://https://k-mos.site
+cors-allow-origin: https://k-mos.site

--- a/backend/src/test/java/mos/MosApplicationTests.java
+++ b/backend/src/test/java/mos/MosApplicationTests.java
@@ -6,8 +6,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class MosApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
 
 }

--- a/backend/src/test/java/mos/integration/CategoryIntegrationTest.java
+++ b/backend/src/test/java/mos/integration/CategoryIntegrationTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import mos.category.dto.CategoriesResponse;
 import mos.category.dto.CreateCategoryRequest;
 import mos.category.entity.Category;
+import mos.integration.dto.MemberDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
@@ -21,12 +22,15 @@ class CategoryIntegrationTest extends IntegrationTest {
 
     private Category category1;
     private Category category2;
+    private MemberDto member1;
     private Long initCategoryCount;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
         category1 = Category.createCategory("카테고리 이름1");
         category2 = Category.createCategory("카테고리 이름2");
+
+        member1 = createMember("member1");
 
         entityManager.persist(category1);
         entityManager.persist(category2);
@@ -47,7 +51,8 @@ class CategoryIntegrationTest extends IntegrationTest {
         // when
         this.mockMvc.perform(post("/api/categories/create")
                         .content(jsonRequest)
-                        .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, member1.createAuthorizationHeader()))
                 .andExpect(status().isCreated())
                 .andExpect(header().exists(HttpHeaders.LOCATION));
 
@@ -60,7 +65,8 @@ class CategoryIntegrationTest extends IntegrationTest {
     @Test
     void 카테고리_전체_조회_테스트() throws Exception {
         // given
-        MvcResult result = this.mockMvc.perform(get("/api/categories"))
+        MvcResult result = this.mockMvc.perform(get("/api/categories")
+                        .header(HttpHeaders.AUTHORIZATION, member1.createAuthorizationHeader()))
                 .andExpect(status().isOk())
                 .andReturn();
 

--- a/backend/src/test/java/mos/integration/IntegrationTest.java
+++ b/backend/src/test/java/mos/integration/IntegrationTest.java
@@ -1,14 +1,34 @@
 package mos.integration;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityManager;
+import jakarta.servlet.http.Cookie;
 import jakarta.transaction.Transactional;
+import mos.auth.domain.GoogleOauthWebClient;
+import mos.auth.dto.OauthAccessTokenResponse;
+import mos.auth.dto.OauthLoginRequest;
+import mos.auth.dto.OauthUserProfileResponse;
+import mos.auth.dto.TokenResponse;
+import mos.integration.dto.LoginResponse;
+import mos.integration.dto.MemberDto;
+import mos.member.dto.MemberResponse;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.nio.charset.StandardCharsets;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(ReplaceUnderscores.class)
@@ -23,6 +43,45 @@ class IntegrationTest {
     @Autowired
     protected MockMvc mockMvc;
 
+    @MockBean
+    protected GoogleOauthWebClient googleOauthWebClient;
+
     @Autowired
     protected ObjectMapper objectMapper;
+
+    public LoginResponse 구글_로그인(String name) throws Exception {
+        OauthLoginRequest request = new OauthLoginRequest("google", "oauthLoginCode");
+        String jsonRequest = objectMapper.writeValueAsString(request);
+
+        given(googleOauthWebClient.requestOauthAccessToken(any(String.class)))
+                .willReturn(new OauthAccessTokenResponse("mock-token-type", "mock-access-token",
+                        "mock-scope"));
+        given(googleOauthWebClient.requestOauthUserProfile(any(String.class)))
+                .willReturn(new OauthUserProfileResponse(name, "mock-email", "mock-picture"));
+
+        MvcResult result = mockMvc.perform(
+                        post("/api/auth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(jsonRequest))
+                .andReturn();
+
+        String jsonResponse = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
+        Cookie refreshToken = result.getResponse().getCookie("refreshToken");
+        TokenResponse tokenResponse = objectMapper.readValue(jsonResponse, TokenResponse.class);
+        return new LoginResponse(tokenResponse.accessToken(), refreshToken);
+    }
+
+    protected MemberDto createMember(String name) throws Exception {
+        LoginResponse loginResponse = 구글_로그인(name);
+
+        MvcResult result = mockMvc.perform(get("/api/members/me")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, loginResponse.createAuthorizationHeader())
+        ).andReturn();
+
+        String jsonResponse = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
+        MemberResponse response = objectMapper.readValue(jsonResponse, MemberResponse.class);
+
+        return new MemberDto(response.id(), loginResponse);
+    }
 }

--- a/backend/src/test/java/mos/integration/MogakoIntegrationTest.java
+++ b/backend/src/test/java/mos/integration/MogakoIntegrationTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import mos.category.entity.Category;
 import mos.hashtag.entity.Hashtag;
+import mos.integration.dto.MemberDto;
 import mos.mogako.dto.CreateMogakoRequest;
 import mos.mogako.dto.MogakoResponse;
 import mos.mogako.dto.MogakosResponse;
@@ -34,9 +35,10 @@ class MogakoIntegrationTest extends IntegrationTest {
     private Hashtag hashtag3;
     private Mogako mogako1;
     private Mogako mogako2;
+    private MemberDto member1;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
         category1 = Category.createCategory("카테고리 이름1");
         category2 = Category.createCategory("카테고리 이름2");
 
@@ -53,6 +55,8 @@ class MogakoIntegrationTest extends IntegrationTest {
                 LocalDateTime.now().plusDays(2L), LocalDateTime.now().plusDays(3L),
                 10, 4,
                 "모각코 상세설명2");
+
+        member1 = createMember("member1");
 
         entityManager.persist(category1);
         entityManager.persist(category2);
@@ -82,7 +86,8 @@ class MogakoIntegrationTest extends IntegrationTest {
         // when
         this.mockMvc.perform(post("/api/mogakos/create")
                         .content(jsonRequest)
-                        .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, member1.createAuthorizationHeader()))
                 .andExpect(status().isCreated())
                 .andExpect(header().exists(HttpHeaders.LOCATION));
 
@@ -96,7 +101,8 @@ class MogakoIntegrationTest extends IntegrationTest {
     void 모각코_조회_테스트() throws Exception {
         // given
         MvcResult result = this.mockMvc.perform(get("/api/mogakos/{mogakoId}", mogako1.getId())
-                        .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, member1.createAuthorizationHeader()))
                 .andExpect(status().isOk())
                 .andReturn();
 
@@ -133,7 +139,8 @@ class MogakoIntegrationTest extends IntegrationTest {
         // then
         this.mockMvc.perform(put("/api/mogakos/{mogakoId}", mogako1.getId())
                         .content(request)
-                        .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, member1.createAuthorizationHeader()))
                 .andExpect(status().isNoContent())
                 .andExpect(header().exists(HttpHeaders.LOCATION));
     }
@@ -151,7 +158,8 @@ class MogakoIntegrationTest extends IntegrationTest {
         // when
         MvcResult result = this.mockMvc.perform(get("/api/mogakos")
                         .queryParams(params)
-                        .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, member1.createAuthorizationHeader()))
                 .andExpect(status().isOk())
                 .andReturn();
 

--- a/backend/src/test/java/mos/integration/dto/LoginResponse.java
+++ b/backend/src/test/java/mos/integration/dto/LoginResponse.java
@@ -1,0 +1,10 @@
+package mos.integration.dto;
+
+import jakarta.servlet.http.Cookie;
+
+public record LoginResponse(String accessToken, Cookie refreshToken) {
+
+    public String createAuthorizationHeader() {
+        return "Bearer " + accessToken;
+    }
+}

--- a/backend/src/test/java/mos/integration/dto/MemberDto.java
+++ b/backend/src/test/java/mos/integration/dto/MemberDto.java
@@ -1,0 +1,8 @@
+package mos.integration.dto;
+
+public record MemberDto(Long memberId, LoginResponse loginResponse) {
+
+    public String createAuthorizationHeader() {
+        return loginResponse().createAuthorizationHeader();
+    }
+}


### PR DESCRIPTION
- closed #100 

# 구현사항
- refreshToken 이 로그인 요청 시 자동으로 쿠키에 등록될 수 있도록 처리했습니다.
- https://k-mos.site 도메인이 https 인증을 받음에 따라 관련 보안 옵션들을 활성화했습니다.
- 인증 및 인가 기능을 활성화하여 이제부터는 정상적으로 로그인 과정을 거쳐야 api 기능들을 이용할 수 있습니다. (로그인 관련 로직 제외)
  - 인증 및 인가 기능 활성화로 인해 통합 테스트 부분이 전부 실패하는 상황입니다. 제가 구현한 부분에 대해서는 조치를 취해뒀는데 수빈님께서 작업하신 코드는 따로 수정하지 않은 상태입니다. 조만간 모각코 참여 기능까지 구현 완료하고 수정해보겠습니다.