### PR TITLE
[BE] 카테고리, 해시태그 기반 모각코 일정 조회 기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -38,6 +38,12 @@ dependencies {
 
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    //Querydsl 추가
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/mos/config/BeanConfiguration.java
+++ b/backend/src/main/java/mos/config/BeanConfiguration.java
@@ -1,0 +1,15 @@
+package mos.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class BeanConfiguration {
+
+    @Bean
+    JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/backend/src/main/java/mos/mogako/controller/MogakoController.java
+++ b/backend/src/main/java/mos/mogako/controller/MogakoController.java
@@ -15,6 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.util.List;
 
 @Tag(name = "모각코 관련 API")
 @RestController
@@ -25,8 +26,10 @@ public class MogakoController {
 
     @Operation(summary = "전체 모각코 목록 조회")
     @GetMapping("/api/mogakos")
-    public ResponseEntity<MogakosResponse> findMogakos(Pageable pageable) {
-        return ResponseEntity.ok(mogakoService.findAll(pageable));
+    public ResponseEntity<MogakosResponse> findMogakos(
+            @RequestParam(required = false, name = "category") List<Long> categoryIds,
+            @RequestParam(required = false, name = "hashtag") List<Long> hashtagIds, Pageable pageable) {
+        return ResponseEntity.ok(mogakoService.findAllWithFiltering(categoryIds, hashtagIds, pageable));
     }
 
     @Operation(summary = "단일 모각코 상세정보 조회")

--- a/backend/src/main/java/mos/mogako/entity/Mogako.java
+++ b/backend/src/main/java/mos/mogako/entity/Mogako.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import mos.category.entity.Category;
 import mos.common.entity.BaseTimeEntity;
 import mos.hashtag.entity.Hashtag;
@@ -20,6 +21,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
 public class Mogako extends BaseTimeEntity {
 
     @Id

--- a/backend/src/main/java/mos/mogako/entity/Mogako.java
+++ b/backend/src/main/java/mos/mogako/entity/Mogako.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 import mos.category.entity.Category;
 import mos.common.entity.BaseTimeEntity;
 import mos.hashtag.entity.Hashtag;
@@ -21,7 +20,6 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@ToString
 public class Mogako extends BaseTimeEntity {
 
     @Id

--- a/backend/src/main/java/mos/mogako/repository/MogakoRepository.java
+++ b/backend/src/main/java/mos/mogako/repository/MogakoRepository.java
@@ -3,6 +3,6 @@ package mos.mogako.repository;
 import mos.mogako.entity.Mogako;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MogakoRepository extends JpaRepository<Mogako, Long> {
+public interface MogakoRepository extends JpaRepository<Mogako, Long>, MogakoRepositoryCustom {
 
 }

--- a/backend/src/main/java/mos/mogako/repository/MogakoRepositoryCustom.java
+++ b/backend/src/main/java/mos/mogako/repository/MogakoRepositoryCustom.java
@@ -1,0 +1,12 @@
+package mos.mogako.repository;
+
+import mos.mogako.entity.Mogako;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface MogakoRepositoryCustom {
+
+    Page<Mogako> findAllWithFiltering(List<Long> categoryIds, List<Long> hashtagIds, Pageable pageable);
+}

--- a/backend/src/main/java/mos/mogako/repository/MogakoRepositoryImpl.java
+++ b/backend/src/main/java/mos/mogako/repository/MogakoRepositoryImpl.java
@@ -55,14 +55,14 @@ public class MogakoRepositoryImpl implements MogakoRepositoryCustom {
         return new PageImpl<>(content, pageable, total);
     }
 
-    private static BooleanExpression containsAnyCategory(List<Long> categoryIds) {
+    private BooleanExpression containsAnyCategory(List<Long> categoryIds) {
         if (categoryIds == null) {
             return null;
         }
         return mogako.category.id.in(categoryIds);
     }
 
-    private static BooleanExpression containsAllHashtag(List<Long> hashtagIds) {
+    private BooleanExpression containsAllHashtag(List<Long> hashtagIds) {
         if (hashtagIds == null) {
             return null;
         }

--- a/backend/src/main/java/mos/mogako/repository/MogakoRepositoryImpl.java
+++ b/backend/src/main/java/mos/mogako/repository/MogakoRepositoryImpl.java
@@ -1,0 +1,76 @@
+package mos.mogako.repository;
+
+import static mos.hashtag.entity.QMogakoHashtag.mogakoHashtag;
+import static mos.mogako.entity.QMogako.mogako;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import mos.mogako.entity.Mogako;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class MogakoRepositoryImpl implements MogakoRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+
+    /*
+     * 카테고리는 하나만 포함되어도 됨
+     * 해시태그는 전부 포함되어야 함
+     *
+     * "select m "
+     * "from Mogako m "
+     * "where m.id in (select mh.mogako.id "
+     *                  "from MogakoHashtag mh "
+     *                  "where mh.hashtag.id in :hashtagIds "
+     *                  "group by mh.mogako.id "
+     *                  "having count(distinct mh.hashtag.id) = :hashtagIdsSize) "
+     * "and m.category.id in :categoryIds"
+     */
+    @Override
+    public Page<Mogako> findAllWithFiltering(List<Long> categoryIds, List<Long> hashtagIds, Pageable pageable) {
+        List<Mogako> content = queryFactory
+                .selectFrom(mogako)
+                .where(containsAnyCategory(categoryIds),
+                        containsAllHashtag(hashtagIds)
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = queryFactory
+                .select(mogako.count())
+                .from(mogako)
+                .where(containsAnyCategory(categoryIds),
+                        containsAllHashtag(hashtagIds)
+                )
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    private static BooleanExpression containsAnyCategory(List<Long> categoryIds) {
+        if (categoryIds == null) {
+            return null;
+        }
+        return mogako.category.id.in(categoryIds);
+    }
+
+    private static BooleanExpression containsAllHashtag(List<Long> hashtagIds) {
+        if (hashtagIds == null) {
+            return null;
+        }
+        return mogako.id.in(
+                JPAExpressions.select(mogakoHashtag.mogako.id)
+                        .from(mogakoHashtag)
+                        .where(mogakoHashtag.hashtag.id.in(hashtagIds))
+                        .groupBy(mogakoHashtag.mogako.id)
+                        .having(mogakoHashtag.hashtag.id.countDistinct().eq((long) hashtagIds.size())));
+    }
+}

--- a/backend/src/main/java/mos/mogako/service/MogakoService.java
+++ b/backend/src/main/java/mos/mogako/service/MogakoService.java
@@ -81,8 +81,8 @@ public class MogakoService {
         return mogako.getId();
     }
 
-    public MogakosResponse findAll(Pageable pageable) {
-        Page<Mogako> mogakos = mogakoRepository.findAll(pageable);
+    public MogakosResponse findAllWithFiltering(List<Long> categoryIds, List<Long> hashtagIds, Pageable pageable) {
+        Page<Mogako> mogakos = mogakoRepository.findAllWithFiltering(categoryIds, hashtagIds, pageable);
         return MogakosResponse.from(mogakos);
     }
 }

--- a/backend/src/test/java/mos/mogako/repository/MogakoRepositoryTest.java
+++ b/backend/src/test/java/mos/mogako/repository/MogakoRepositoryTest.java
@@ -1,0 +1,237 @@
+package mos.mogako.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import jakarta.persistence.EntityManager;
+import mos.category.entity.Category;
+import mos.hashtag.entity.Hashtag;
+import mos.member.entity.Member;
+import mos.mogako.entity.Mogako;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@SpringBootTest
+@Transactional
+public class MogakoRepositoryTest {
+
+    @Autowired
+    private MogakoRepository mogakoRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private Member member1;
+    private Category category1;
+    private Category category2;
+    private Hashtag hashtag1;
+    private Hashtag hashtag2;
+    private Mogako category1NoHashtag;
+    private Mogako category1Hashtag1;
+    private Mogako category1Hashtag2;
+    private Mogako category1Hashtag12;
+    private Mogako category2Hashtag1;
+    private Mogako category2Hashtag2;
+    private Mogako category2Hashtag12;
+    private int totalMogakoCounts;
+
+    @BeforeEach
+    void setUp() {
+        member1 = Member.createNewMember("member1", "email", "profile");
+
+        category1 = Category.createCategory("category1");
+        category2 = Category.createCategory("category2");
+
+        hashtag1 = Hashtag.createNewHashtag("hashtag1");
+        hashtag2 = Hashtag.createNewHashtag("hashtag2");
+
+        List<Hashtag> hashtags1 = List.of(hashtag1);
+        List<Hashtag> hashtags2 = List.of(hashtag2);
+        List<Hashtag> hashtags12 = List.of(hashtag1, hashtag2);
+
+        category1NoHashtag = Mogako.createNewMogako("카테고리1 모각코", "모각코 짧은 소개",
+                category1, List.of(),
+                LocalDateTime.now().plusDays(1L), LocalDateTime.now().plusDays(2L),
+                8, 2,
+                "모각코 상세설명");
+
+        category1Hashtag1 = Mogako.createNewMogako("카테고리1 해시태그1 모각코", "모각코 짧은 소개",
+                category1, hashtags1,
+                LocalDateTime.now().plusDays(1L), LocalDateTime.now().plusDays(2L),
+                8, 2,
+                "모각코 상세설명");
+
+        category1Hashtag2 = Mogako.createNewMogako("카테고리1 해시태그2 모각코", "모각코 짧은 소개",
+                category1, hashtags2,
+                LocalDateTime.now().plusDays(1L), LocalDateTime.now().plusDays(2L),
+                8, 2,
+                "모각코 상세설명");
+
+        category1Hashtag12 = Mogako.createNewMogako("카테고리1 해시태그12 모각코", "모각코 짧은 소개",
+                category1, hashtags12,
+                LocalDateTime.now().plusDays(1L), LocalDateTime.now().plusDays(2L),
+                8, 2,
+                "모각코 상세설명");
+
+        category2Hashtag1 = Mogako.createNewMogako("카테고리2 해시태그1 모각코", "모각코 짧은 소개",
+                category2, hashtags1,
+                LocalDateTime.now().plusDays(1L), LocalDateTime.now().plusDays(2L),
+                8, 2,
+                "모각코 상세설명");
+
+        category2Hashtag2 = Mogako.createNewMogako("카테고리2 해시태그2 모각코", "모각코 짧은 소개",
+                category2, hashtags2,
+                LocalDateTime.now().plusDays(1L), LocalDateTime.now().plusDays(2L),
+                8, 2,
+                "모각코 상세설명");
+
+        category2Hashtag12 = Mogako.createNewMogako("카테고리2 해시태그12 모각코", "모각코 짧은 소개",
+                category2, hashtags12,
+                LocalDateTime.now().plusDays(1L), LocalDateTime.now().plusDays(2L),
+                8, 2,
+                "모각코 상세설명");
+
+        totalMogakoCounts = 7;
+
+        entityManager.persist(member1);
+        entityManager.persist(category1);
+        entityManager.persist(category2);
+        entityManager.persist(hashtag1);
+        entityManager.persist(hashtag2);
+
+        entityManager.persist(category1NoHashtag);
+        entityManager.persist(category1Hashtag1);
+        entityManager.persist(category1Hashtag2);
+        entityManager.persist(category1Hashtag12);
+        entityManager.persist(category2Hashtag1);
+        entityManager.persist(category2Hashtag2);
+        entityManager.persist(category2Hashtag12);
+
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    @Test
+    void 카테고리_해시태그_동적쿼리() {
+        //given
+        List<Long> categoryIds = null;
+        List<Long> hashtagIds = List.of(hashtag1.getId());
+        PageRequest pageRequest = PageRequest.of(0, 100);
+
+        //when
+        Page<Mogako> results = mogakoRepository.findAllWithFiltering(categoryIds, hashtagIds, pageRequest);
+
+        //then
+        for (Mogako mogako : results.getContent()) {
+            System.out.println("mogako = " + mogako);
+        }
+
+    }
+
+    @Test
+    void 아무_조건도_입력되지_않으면_전체_모각코를_페이징해서_반환한다() {
+        //given
+        List<Long> categoryIds = null;
+        List<Long> hashtagIds = null;
+
+        int pageSize = 2;
+        PageRequest pageRequest = PageRequest.of(0, pageSize);
+
+        //when
+        Page<Mogako> results = mogakoRepository.findAllWithFiltering(categoryIds, hashtagIds, pageRequest);
+
+        //then
+        assertSoftly(softly -> {
+            softly.assertThat(results.getContent().size()).isEqualTo(pageSize);
+            softly.assertThat(results.getTotalElements()).isEqualTo(totalMogakoCounts);
+            softly.assertThat(results.getTotalPages()).isEqualTo((totalMogakoCounts / pageSize) + 1);
+        });
+    }
+
+    @Test
+    void 카테고리_조건만_입력되면_카테고리만_필터링해서_반환한다() {
+        //given
+        List<Long> categoryIds = List.of(category1.getId());
+        List<Long> hashtagIds = null;
+        int pageSize = 10;
+        PageRequest pageRequest = PageRequest.of(0, pageSize);
+
+        //when
+        Page<Mogako> results = mogakoRepository.findAllWithFiltering(categoryIds, hashtagIds, pageRequest);
+
+        //then
+        assertThat(results.getContent()).extracting("id")
+                .containsExactly(
+                        category1NoHashtag.getId(),
+                        category1Hashtag1.getId(),
+                        category1Hashtag2.getId(),
+                        category1Hashtag12.getId());
+    }
+
+    @Test
+    void 카테고리_필터링_조건은_or_조건으로_적용된다() {
+        //given
+        List<Long> categoryIds = List.of(category1.getId(), category2.getId());
+        List<Long> hashtagIds = null;
+        int pageSize = 10;
+        PageRequest pageRequest = PageRequest.of(0, pageSize);
+
+        //when
+        Page<Mogako> results = mogakoRepository.findAllWithFiltering(categoryIds, hashtagIds, pageRequest);
+
+        //then
+        assertThat(results.getContent()).extracting("id")
+                .containsExactly(
+                        category1NoHashtag.getId(),
+                        category1Hashtag1.getId(),
+                        category1Hashtag2.getId(),
+                        category1Hashtag12.getId(),
+                        category2Hashtag1.getId(),
+                        category2Hashtag2.getId(),
+                        category2Hashtag12.getId());
+    }
+
+    @Test
+    void 해시태그_조건이_입력되면_카테고리와_해시태그_조건으로_필터링해서_반환한다() {
+        //given
+        List<Long> categoryIds = List.of(category1.getId());
+        List<Long> hashtagIds = List.of(hashtag1.getId());
+        int pageSize = 10;
+        PageRequest pageRequest = PageRequest.of(0, pageSize);
+
+        //when
+        Page<Mogako> results = mogakoRepository.findAllWithFiltering(categoryIds, hashtagIds, pageRequest);
+
+        //then
+        assertThat(results.getContent()).extracting("id")
+                .containsExactly(
+                        category1Hashtag1.getId(),
+                        category1Hashtag12.getId());
+    }
+
+    @Test
+    void 해시태그_조건은_and_조건으로_적용된다() {
+        //given
+        List<Long> categoryIds = List.of(category1.getId(), category2.getId());
+        List<Long> hashtagIds = List.of(hashtag1.getId(), hashtag2.getId());
+        int pageSize = 10;
+        PageRequest pageRequest = PageRequest.of(0, pageSize);
+
+        //when
+        Page<Mogako> results = mogakoRepository.findAllWithFiltering(categoryIds, hashtagIds, pageRequest);
+
+        //then
+        assertThat(results.getContent()).extracting("id")
+                .containsExactly(
+                        category1Hashtag12.getId(),
+                        category2Hashtag12.getId());
+    }
+}

--- a/backend/src/test/java/mos/mogako/service/MogakoServiceTest.java
+++ b/backend/src/test/java/mos/mogako/service/MogakoServiceTest.java
@@ -10,6 +10,7 @@ import mos.hashtag.entity.Hashtag;
 import mos.member.entity.Member;
 import mos.mogako.dto.CreateMogakoRequest;
 import mos.mogako.dto.MogakoResponse;
+import mos.mogako.dto.MogakosResponse;
 import mos.mogako.dto.UpdateMogakoRequest;
 import mos.mogako.entity.Mogako;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -144,34 +146,34 @@ class MogakoServiceTest {
         });
     }
 
-//    @Test
-//    void 전체_모각코_목록을_페이지_조회한다() {
-//        // given
-//        int pageNumber = 1;
-//        int pageSize = 2;
-//        int totalElements = 10;
-//
-//        for (int i = 1; i < totalElements; i++) {
-//            entityManager.persist(Mogako.createNewMogako("모각코 이름" + i, "모각코 짧은 소개",
-//                    category1, List.of(hashtag1, hashtag2),
-//                    LocalDateTime.now().plusDays(1L), LocalDateTime.now().plusDays(2L),
-//                    8, 2,
-//                    "모각코 상세설명"));
-//        }
-//        entityManager.flush();
-//        entityManager.clear();
-//
-//        PageRequest request = PageRequest.of(pageNumber, pageSize);
-//
-//        // when
-//        MogakosResponse response = mogakoService.findAllWithFiltering(request);
-//
-//        // then
-//        assertSoftly((softly) -> {
-//            softly.assertThat(response.pageNumber()).isEqualTo(pageNumber);
-//            softly.assertThat(response.mogakos().size()).isEqualTo(pageSize);
-//            softly.assertThat(response.totalPages()).isEqualTo(totalElements / pageSize);
-//            softly.assertThat(response.totalElements()).isEqualTo(totalElements);
-//        });
-//    }
+    @Test
+    void 전체_모각코_목록을_페이지_조회한다() {
+        // given
+        int pageNumber = 1;
+        int pageSize = 2;
+        int totalElements = 10;
+
+        for (int i = 1; i < totalElements; i++) {
+            entityManager.persist(Mogako.createNewMogako("모각코 이름" + i, "모각코 짧은 소개",
+                    category1, List.of(hashtag1, hashtag2),
+                    LocalDateTime.now().plusDays(1L), LocalDateTime.now().plusDays(2L),
+                    8, 2,
+                    "모각코 상세설명"));
+        }
+        entityManager.flush();
+        entityManager.clear();
+
+        PageRequest request = PageRequest.of(pageNumber, pageSize);
+
+        // when
+        MogakosResponse response = mogakoService.findAllWithFiltering(null, null, request);
+
+        // then
+        assertSoftly((softly) -> {
+            softly.assertThat(response.pageNumber()).isEqualTo(pageNumber);
+            softly.assertThat(response.mogakos().size()).isEqualTo(pageSize);
+            softly.assertThat(response.totalPages()).isEqualTo(totalElements / pageSize);
+            softly.assertThat(response.totalElements()).isEqualTo(totalElements);
+        });
+    }
 }

--- a/backend/src/test/java/mos/mogako/service/MogakoServiceTest.java
+++ b/backend/src/test/java/mos/mogako/service/MogakoServiceTest.java
@@ -10,7 +10,6 @@ import mos.hashtag.entity.Hashtag;
 import mos.member.entity.Member;
 import mos.mogako.dto.CreateMogakoRequest;
 import mos.mogako.dto.MogakoResponse;
-import mos.mogako.dto.MogakosResponse;
 import mos.mogako.dto.UpdateMogakoRequest;
 import mos.mogako.entity.Mogako;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,7 +18,6 @@ import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.PageRequest;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -146,34 +144,34 @@ class MogakoServiceTest {
         });
     }
 
-    @Test
-    void 전체_모각코_목록을_페이지_조회한다() {
-        // given
-        int pageNumber = 1;
-        int pageSize = 2;
-        int totalElements = 10;
-
-        for (int i = 1; i < totalElements; i++) {
-            entityManager.persist(Mogako.createNewMogako("모각코 이름" + i, "모각코 짧은 소개",
-                    category1, List.of(hashtag1, hashtag2),
-                    LocalDateTime.now().plusDays(1L), LocalDateTime.now().plusDays(2L),
-                    8, 2,
-                    "모각코 상세설명"));
-        }
-        entityManager.flush();
-        entityManager.clear();
-
-        PageRequest request = PageRequest.of(pageNumber, pageSize);
-
-        // when
-        MogakosResponse response = mogakoService.findAll(request);
-
-        // then
-        assertSoftly((softly) -> {
-            softly.assertThat(response.pageNumber()).isEqualTo(pageNumber);
-            softly.assertThat(response.mogakos().size()).isEqualTo(pageSize);
-            softly.assertThat(response.totalPages()).isEqualTo(totalElements / pageSize);
-            softly.assertThat(response.totalElements()).isEqualTo(totalElements);
-        });
-    }
+//    @Test
+//    void 전체_모각코_목록을_페이지_조회한다() {
+//        // given
+//        int pageNumber = 1;
+//        int pageSize = 2;
+//        int totalElements = 10;
+//
+//        for (int i = 1; i < totalElements; i++) {
+//            entityManager.persist(Mogako.createNewMogako("모각코 이름" + i, "모각코 짧은 소개",
+//                    category1, List.of(hashtag1, hashtag2),
+//                    LocalDateTime.now().plusDays(1L), LocalDateTime.now().plusDays(2L),
+//                    8, 2,
+//                    "모각코 상세설명"));
+//        }
+//        entityManager.flush();
+//        entityManager.clear();
+//
+//        PageRequest request = PageRequest.of(pageNumber, pageSize);
+//
+//        // when
+//        MogakosResponse response = mogakoService.findAllWithFiltering(request);
+//
+//        // then
+//        assertSoftly((softly) -> {
+//            softly.assertThat(response.pageNumber()).isEqualTo(pageNumber);
+//            softly.assertThat(response.mogakos().size()).isEqualTo(pageSize);
+//            softly.assertThat(response.totalPages()).isEqualTo(totalElements / pageSize);
+//            softly.assertThat(response.totalElements()).isEqualTo(totalElements);
+//        });
+//    }
 }


### PR DESCRIPTION
# 구현사항
- queryDSL을 활용하여 모각코 일정 필터링 조회 시 필요한 동적 쿼리 기능을 구현했습니다.
