### PR TITLE
[BE] 모각코 일정 참여 시 인원 제한 로직의 동시성 이슈 해결

### DIFF
--- a/backend/src/main/java/mos/mogako/entity/Mogako.java
+++ b/backend/src/main/java/mos/mogako/entity/Mogako.java
@@ -44,15 +44,19 @@ public class Mogako extends BaseTimeEntity {
     private LocalDateTime startDate;
     private LocalDateTime endDate;
     private Integer participantLimit;
+    private Integer currentParticipantCount;
     private Integer minimumParticipantCount;
     private String detailContent;
 
     @Enumerated(EnumType.STRING)
     private Status status;
 
+    @Version
+    private Long version;
+
     private Mogako(String name, String summary, Category category, List<Hashtag> hashtags,
                    LocalDateTime startDate, LocalDateTime endDate,
-                   Integer participantLimit, Integer minimumParticipantCount,
+                   Integer participantLimit, Integer currentParticipantCount, Integer minimumParticipantCount,
                    String detailContent, Status status) {
         this.category = category;
         addMogakoHashtags(hashtags);
@@ -61,6 +65,7 @@ public class Mogako extends BaseTimeEntity {
         this.startDate = startDate;
         this.endDate = endDate;
         this.participantLimit = participantLimit;
+        this.currentParticipantCount = currentParticipantCount;
         this.minimumParticipantCount = minimumParticipantCount;
         this.detailContent = detailContent;
         this.status = status;
@@ -71,7 +76,7 @@ public class Mogako extends BaseTimeEntity {
                                          Integer participantLimit, Integer minimumParticipantCount,
                                          String detailContent) {
         return new Mogako(name, summary, category, hashtags, startDate, endDate,
-                participantLimit, minimumParticipantCount, detailContent, Status.RECRUITING);
+                participantLimit, 0, minimumParticipantCount, detailContent, Status.RECRUITING);
     }
 
     private void addMogakoHashtags(List<Hashtag> hashtags) {

--- a/backend/src/main/java/mos/mogako/entity/Mogako.java
+++ b/backend/src/main/java/mos/mogako/entity/Mogako.java
@@ -112,9 +112,10 @@ public class Mogako extends BaseTimeEntity {
     }
 
     public void participate(Participant participant) {
-        if (this.participants.size() >= this.participantLimit) {
+        if (currentParticipantCount >= this.participantLimit) {
             throw new ParticipantLimitExceededException();
         }
+        currentParticipantCount++;
         this.participants.add(participant);
     }
 

--- a/backend/src/main/java/mos/mogako/repository/MogakoRepository.java
+++ b/backend/src/main/java/mos/mogako/repository/MogakoRepository.java
@@ -1,8 +1,19 @@
 package mos.mogako.repository;
 
+import jakarta.persistence.LockModeType;
 import mos.mogako.entity.Mogako;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface MogakoRepository extends JpaRepository<Mogako, Long>, MogakoRepositoryCustom {
 
+    @Query("select m from Mogako m join fetch m.participants as p where m.id = :mogakoId")
+    Optional<Mogako> findByIdWithParticipants(Long mogakoId);
+
+    @Lock(LockModeType.OPTIMISTIC)
+    @Query("select m from Mogako m where m.id = :mogakoId")
+    Optional<Mogako> findByIdWithOptimisticLock(Long mogakoId);
 }

--- a/backend/src/main/java/mos/participant/controller/ParticipantController.java
+++ b/backend/src/main/java/mos/participant/controller/ParticipantController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import mos.auth.domain.Authenticated;
 import mos.participant.dto.ParticipantResponse;
 import mos.participant.service.ParticipantService;
+import mos.participant.service.ParticipantServiceFacade;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,10 +19,11 @@ import java.util.List;
 public class ParticipantController {
 
     private final ParticipantService participantService;
+    private final ParticipantServiceFacade participantServiceFacade;
 
     @PostMapping("/api/mogakos/{mogakoId}/participate")
     public ResponseEntity<Void> participate(@Authenticated Long authMemberId, @PathVariable Long mogakoId) {
-        Long participantId = participantService.participate(authMemberId, mogakoId);
+        Long participantId = participantServiceFacade.participate(authMemberId, mogakoId);
         return ResponseEntity.created(URI.create("/api/participants/" + participantId)).build();
     }
 

--- a/backend/src/main/java/mos/participant/service/ParticipantService.java
+++ b/backend/src/main/java/mos/participant/service/ParticipantService.java
@@ -1,5 +1,6 @@
 package mos.participant.service;
 
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import mos.member.entity.Member;
 import mos.member.exception.MemberNotFoundException;
@@ -11,21 +12,24 @@ import mos.participant.dto.ParticipantResponse;
 import mos.participant.entity.Participant;
 import mos.participant.repository.ParticipantRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class ParticipantService {
 
     private final MemberRepository memberRepository;
     private final MogakoRepository mogakoRepository;
     private final ParticipantRepository participantRepository;
+    private final EntityManager entityManager;
 
     public Long participate(Long authMemberId, Long mogakoId) {
         Member member = memberRepository.findById(authMemberId)
                 .orElseThrow(MemberNotFoundException::new);
-        Mogako mogako = mogakoRepository.findById(mogakoId)
+        Mogako mogako = mogakoRepository.findByIdWithOptimisticLock(mogakoId)
                 .orElseThrow(MogakoNotFoundException::new);
 
         Participant participant = Participant.createNewParticipant(member, mogako, false);

--- a/backend/src/main/java/mos/participant/service/ParticipantServiceFacade.java
+++ b/backend/src/main/java/mos/participant/service/ParticipantServiceFacade.java
@@ -1,0 +1,27 @@
+package mos.participant.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ParticipantServiceFacade {
+
+    private final ParticipantService participantService;
+
+    public Long participate(Long memberId, Long mogakoId) {
+        while (true) {
+            try {
+                return participantService.participate(memberId, mogakoId);
+            } catch (ObjectOptimisticLockingFailureException le) {
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException e) {
+                    break;
+                }
+            }
+        }
+        return -1L;
+    }
+}

--- a/backend/src/test/java/mos/participant/service/ParticipantServiceFacadeTest.java
+++ b/backend/src/test/java/mos/participant/service/ParticipantServiceFacadeTest.java
@@ -1,0 +1,136 @@
+package mos.participant.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import mos.category.entity.Category;
+import mos.category.repository.CategoryRepository;
+import mos.hashtag.entity.Hashtag;
+import mos.hashtag.repository.HashtagRepository;
+import mos.member.entity.Member;
+import mos.member.repository.MemberRepository;
+import mos.mogako.entity.Mogako;
+import mos.mogako.exception.ParticipantLimitExceededException;
+import mos.mogako.repository.MogakoRepository;
+import mos.util.CleanUp;
+import mos.util.TestConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Import(TestConfig.class)
+@SpringBootTest
+class ParticipantServiceFacadeTest {
+
+    @Autowired
+    private ParticipantServiceFacade participantServiceFacade;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private HashtagRepository hashtagRepository;
+
+    @Autowired
+    private MogakoRepository mogakoRepository;
+
+    @Autowired
+    private CleanUp cleanUp;
+
+    private Member member0;
+    private final List<Member> hundredMembers = new ArrayList<>();
+    private Category category1;
+    private Category category2;
+    private Hashtag hashtag1;
+    private Hashtag hashtag2;
+    private Hashtag hashtag3;
+    private Mogako mogako1;
+
+    @BeforeEach
+    void setUp() {
+        member0 = Member.createNewMember("member0", "email", "profile");
+
+        for (int num = 1; num <= 10; num++) {
+            Member temp = Member.createNewMember("member" + num, "email", "profile");
+            memberRepository.save(temp);
+            hundredMembers.add(temp);
+        }
+
+        category1 = Category.createCategory("카테고리 이름1");
+        category2 = Category.createCategory("카테고리 이름2");
+        List<Category> categories = List.of(category1, category2);
+
+        hashtag1 = Hashtag.createNewHashtag("hashtag1");
+        hashtag2 = Hashtag.createNewHashtag("hashtag2");
+        hashtag3 = Hashtag.createNewHashtag("hashtag3");
+        List<Hashtag> hashtags = List.of(hashtag1, hashtag2);
+
+        mogako1 = Mogako.createNewMogako("모각코 이름", "모각코 짧은 소개",
+                category1, List.of(hashtag1, hashtag2),
+                LocalDateTime.now().plusDays(1L), LocalDateTime.now().plusDays(2L),
+                10, 2,
+                "모각코 상세설명");
+
+        memberRepository.save(member0);
+        categoryRepository.saveAll(categories);
+        hashtagRepository.saveAll(hashtags);
+        mogakoRepository.save(mogako1);
+    }
+
+    @AfterEach
+    void tearDown() {
+        cleanUp.all();
+    }
+
+    @RepeatedTest(value = 20)
+    void 인원_제한이_10명인_단일_모각코에_동시에_100명이_참여_신청해도_10명만_참여되어야_한다() throws InterruptedException {
+        // given
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(110);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger wasLimitExceptionCounter = new AtomicInteger();
+        AtomicInteger jpaOptimisticLockExceptionCounter = new AtomicInteger();
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            final int memberNum = i;
+            executorService.submit(() -> {
+                try {
+                    Member member = hundredMembers.get(memberNum);
+                    participantServiceFacade.participate(member.getId(), mogako1.getId());
+                } catch (ParticipantLimitExceededException e) {
+                    wasLimitExceptionCounter.getAndIncrement();
+                } catch (ObjectOptimisticLockingFailureException le) {
+                    jpaOptimisticLockExceptionCounter.getAndIncrement();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+
+        Mogako mogako = mogakoRepository.findByIdWithParticipants(mogako1.getId()).orElseThrow();
+
+        // then
+        assertThat(wasLimitExceptionCounter.get()).isZero();
+        assertThat(jpaOptimisticLockExceptionCounter.get()).isZero();
+        assertThat(mogako.getParticipants()).hasSize(mogako1.getParticipantLimit());
+        assertThat(mogako.getCurrentParticipantCount()).isEqualTo(mogako.getParticipantLimit());
+    }
+
+}

--- a/backend/src/test/java/mos/util/CleanUp.java
+++ b/backend/src/test/java/mos/util/CleanUp.java
@@ -1,0 +1,43 @@
+package mos.util;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.metamodel.EntityType;
+import jakarta.transaction.Transactional;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+
+public class CleanUp {
+    private final JdbcTemplate jdbcTemplate;
+    private final EntityManager entityManager;
+
+    public CleanUp(JdbcTemplate jdbcTemplate, jakarta.persistence.EntityManager entityManager) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.entityManager = entityManager;
+    }
+
+    @Transactional
+    public void all() {
+        List<String> tables = entityManager.getMetamodel().getEntities().stream()
+                .map(EntityType::getName)
+                .map(CleanUp::convertCamelToSnake)
+                .toList();
+
+        jdbcTemplate.execute("SET REFERENTIAL_INTEGRITY FALSE");
+
+        tables.forEach(table -> {
+            jdbcTemplate.execute(String.format("truncate table %s", table));
+        });
+
+        jdbcTemplate.execute("SET REFERENTIAL_INTEGRITY TRUE");
+    }
+
+    private static String convertCamelToSnake(String camelCase) {
+        if (camelCase == null || camelCase.isEmpty()) {
+            return camelCase;
+        }
+
+        // 정규 표현식을 사용하여 대문자 앞에 밑줄을 추가하고 소문자로 변환합니다.
+        return camelCase.replaceAll("([a-z])([A-Z])", "$1_$2").toLowerCase();
+    }
+}

--- a/backend/src/test/java/mos/util/TestConfig.java
+++ b/backend/src/test/java/mos/util/TestConfig.java
@@ -1,0 +1,22 @@
+package mos.util;
+
+import jakarta.persistence.EntityManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@TestConfiguration
+public class TestConfig {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Bean
+    public CleanUp cleanUp() {
+        return new CleanUp(jdbcTemplate, entityManager);
+    }
+}


### PR DESCRIPTION
# 구현 사항
여러 회원이 동시에 같은 모각코 일정에 참여를 요청하면 동시성 문제가 발생하여 인원 제한을 체크하는 비즈니스 로직 검증이 제대로 수행되지 않는 상황이었습니다. 이를 해결하기 위해 JPA의 낙관적 락을 사용하여 제한 인원을 넘기는 참여자가 생기지 않도록 했습니다.

추가적으로 낙관적 락으로 인해 동시성 문제가 발생하면 재처리하는 로직을 처리하게끔 하기 위해 facade 서비스 빈을 생성했습니다. 현재 상황에서는 동시성 문제가 잦게 발생하지는 않을 것이라는 전제하에 성공할 때까지 재시도하게끔 구현을 해뒀는데, 이후 특정 횟수만 재시도한 뒤 예외처리해주는 방향으로 리팩터링 해볼 수 있을 듯 합니다.


# 고민 포인트
기존 Mogako 엔티티 구조에서는 participants 컬렉션으로만 참여자 현황을 관리하고 따로 현재 참여 인원 수를 관리하지 않았기에, version 컬럼을 추가하고 낙관적 락을 적용해도 동시성 문제가 정상적으로 해결되지 않는다는 문제가 있었습니다.
  - participant가 참여하는 작업은 participant 테이블에 해당 member와 mogako PK를 FK로 가지는 레코드가 새로 생성되는 것입니다.
  - version 비교는 mogako 엔티티 테이블에 해당하는 레코드를 확인할텐데, 위 작업으로는 mogako 레코드에 변화가 생기지 않기 때문에 낙관적 락이 정상적으로 동작하지 않는 것이 원인이었습니다.

위 원인을 해결하기 위해 currentParticipantCount 컬럼을 Mogako 엔티티에 추가하는 역정규화를 선제적으로 수행했습니다. 이후 Mogako에서 새로운 참여자를 참여시킬 때 해당 테이블 내 컬럼 값의 변경이 필요하도록 수정하고, version 비교를 통해 낙관적 락이 정상적으로 적용될 수 있도록 했습니다.

